### PR TITLE
lineqn bug fix when data.shape=(1,1)

### DIFF
--- a/linsolve/linsolve.py
+++ b/linsolve/linsolve.py
@@ -174,10 +174,7 @@ class LinearEquation:
         for term in self.terms:
             p = self.prms[get_name(term[-1])]
             f = self.eval_consts(term[:-1], self.wgts)
-            if len(f.flatten()) == 1:
-                x,y,val = p.sparse_form(term[-1], eqnum, prm_order, f, re_im_split)
-            else:
-                x,y,val = p.sparse_form(term[-1], eqnum, prm_order, f.flatten(), re_im_split)
+            x,y,val = p.sparse_form(term[-1], eqnum, prm_order, f.flatten(), re_im_split)
             xs += x; ys += y; vals += val
         return xs, ys, vals
     
@@ -316,7 +313,7 @@ class LinearSolver:
         xs,ys,vals = self.sparse_form()
         ones = np.ones(self._A_shape()[2:],dtype=self.dtype)
         for n,val in enumerate(vals): 
-            if type(val) is not np.ndarray:
+            if not isinstance(val, np.ndarray) or val.size == 1:
                 vals[n] = ones*val
         return np.array(xs), np.array(ys), np.array(vals).T
     

--- a/linsolve/tests/linsolve_test.py
+++ b/linsolve/tests/linsolve_test.py
@@ -446,6 +446,20 @@ class TestLinProductSolver(unittest.TestCase):
         np.testing.assert_almost_equal(sol['x'], x, 2)
         np.testing.assert_almost_equal(sol['y'], y, 2)
         np.testing.assert_almost_equal(sol['z'], z, 2)
+    def test_complex_array_NtimesNfreqs1_solve(self):
+        x = np.arange(1, dtype=np.complex); x.shape = (1,1)
+        y = np.arange(1, dtype=np.complex); y.shape = (1,1)
+        z = np.arange(1, dtype=np.complex); z.shape = (1,1)
+        d,w = {'x*y':x*y, 'x*z':x*z, 'y*z':y*z}, {}
+        for k in list(d.keys()): w[k] = np.ones(d[k].shape)
+        sol0 = {}
+        for k in 'xyz': sol0[k] = eval(k) + .01
+        ls = linsolve.LinProductSolver(d,sol0,w,sparse=self.sparse)
+        ls.prm_order = {'x':0,'y':1,'z':2}
+        sol = ls.solve()
+        np.testing.assert_almost_equal(sol['x'], x, 2)
+        np.testing.assert_almost_equal(sol['y'], y, 2)
+        np.testing.assert_almost_equal(sol['z'], z, 2)
     def test_sums_of_products(self):
         x = np.arange(1,31)*(1.0+1.0j); x.shape=(10,3) 
         y = np.arange(1,31)*(2.0-3.0j); y.shape=(10,3)


### PR DESCRIPTION
Fixes a bug in `LinearEquation` sparse form when data is an `ndarray` of shape `(1, 1)`. The problem was that there was an implicit broadcasting done to make floats into ndarrays with the shape of the data, but this should also be done for len-1 ndarrays, which is now caught and handled. Before this was being handled by using `f` instead of `f.flatten()` in the `LinearEquation` sparse form (which was causing the bug in the first place), but this is now not needed given the proper broadcasting further downstream.

Resolves #26 