### PR TITLE
Remove python 2 tests and support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   # We don't actually use the Travis Python, but this keeps it organized.
-  - "3.6"
   - "3.7"
   - "3.8"
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   # We don't actually use the Travis Python, but this keeps it organized.
   - "3.6"
+  - "3.7"
+  - "3.8"
 install:
   - sudo apt-get update
   # We do this conditionally because it saves us some downloading if the

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,12 @@
 language: python
 python:
   # We don't actually use the Travis Python, but this keeps it organized.
-  - "2.7"
   - "3.6"
 install:
   - sudo apt-get update
   # We do this conditionally because it saves us some downloading if the
   # version is the same.
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
-    else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    fi
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r

--- a/linsolve/__init__.py
+++ b/linsolve/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from .linsolve import *
 from . import version
 

--- a/linsolve/linsolve.py
+++ b/linsolve/linsolve.py
@@ -27,7 +27,6 @@ form 'x*y + y*z'.
 For more detail on usage, see linsolve_example.ipynb
 '''
 
-from __future__ import absolute_import, division, print_function
 import numpy as np
 import ast
 from scipy.sparse import lil_matrix, csr_matrix

--- a/linsolve/linsolve.py
+++ b/linsolve/linsolve.py
@@ -35,27 +35,34 @@ import warnings
 from copy import deepcopy
 from functools import reduce
 
+# Monkey patch for backward compatibility:
+# ast.Num deprecated in Python 3.8. Make it an alias for ast.Constant
+# if it gets removed.
+if not hasattr(ast, 'Num'):
+    ast.Num = ast.Constant
+
 def ast_getterms(n):
     '''Convert an AST parse tree into a list of terms.  E.g. 'a*x1+b*x2' -> [[a,x1],[b,x2]]'''
-    if type(n) is ast.Name: return [[n.id]]
-    elif type(n) is ast.Constant: return [[n.n]]
-    elif type(n) is ast.Expression: return ast_getterms(n.body)
+    if type(n) is ast.Name:
+        return [[n.id]]
+    elif type(n) is ast.Constant or type(n) is ast.Num:
+        return [[n.n]]
+    elif type(n) is ast.Expression:
+        return ast_getterms(n.body)
     elif type(n) is ast.UnaryOp:
         assert(type(n.op) is ast.USub)
         return [[-1]+ast_getterms(n.operand)[0]]
     elif type(n) is ast.BinOp:
         if type(n.op) is ast.Mult:
             return [ast_getterms(n.left)[0] + ast_getterms(n.right)[0]]
-        elif type(n.op) is ast.Add: return ast_getterms(n.left) + ast_getterms(n.right)
-        elif type(n.op) is ast.Sub: return ast_getterms(n.left) + [[-1] + ast_getterms(n.right)[0]]
-        else: raise ValueError('Unsupported operation: %s' % str(n.op))
-
-    try:  # Backwards compatibility: ast.Num is used in python 3.7 but deprecated in python 3.8.
-        if type(n) is ast.Num: return [[n.n]]
-    except: # This will allow allow this check to fail gracefully when ast.Num is removed
-        pass
-
-    raise ValueError('Unsupported: %s' % str(n))
+        elif type(n.op) is ast.Add:
+            return ast_getterms(n.left) + ast_getterms(n.right)
+        elif type(n.op) is ast.Sub:
+            return ast_getterms(n.left) + [[-1] + ast_getterms(n.right)[0]]
+        else:
+            raise ValueError('Unsupported operation: %s' % str(n.op))
+    else:
+        raise ValueError('Unsupported: %s' % str(n))
 
 def get_name(s, isconj=False):
     '''Parse variable names of form 'var_' as 'var' + conjugation.'''

--- a/linsolve/tests/linsolve_test.py
+++ b/linsolve/tests/linsolve_test.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 import unittest
 import linsolve
 import numpy as np

--- a/linsolve/version.py
+++ b/linsolve/version.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import json
 import os
 import subprocess

--- a/linsolve_example.ipynb
+++ b/linsolve_example.ipynb
@@ -1,6 +1,20 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-06-13T00:48:15.534405Z",
+     "start_time": "2020-06-13T00:48:15.253820Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import ast, linsolve"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "run_control": {
@@ -16,13 +30,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2018-06-18T18:49:31.973690Z",
-     "start_time": "2018-06-18T18:49:31.771217Z"
+     "end_time": "2020-06-13T00:29:02.687347Z",
+     "start_time": "2020-06-13T00:29:02.245024Z"
     },
-    "collapsed": true,
     "run_control": {
      "frozen": false,
      "read_only": false
@@ -56,27 +69,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2018-06-18T18:49:32.082076Z",
-     "start_time": "2018-06-18T18:49:31.975617Z"
+     "end_time": "2020-06-13T00:29:02.782442Z",
+     "start_time": "2020-06-13T00:29:02.688957Z"
     },
     "run_control": {
      "frozen": false,
      "read_only": false
-    }
+    },
+    "scrolled": false
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'y': 2.0, 'x': 1.0}\n"
+      "{'x': 1.0, 'y': 2.0}\n"
      ]
     }
    ],
    "source": [
+    "import numpy as np\n",
+    "import linsolve\n",
+    "\n",
     "#Set up dictionary of equations\n",
     "data = {'3*x+4*y': 11.0, '-1*x-3*y': -7.0}\n",
     "\n",
@@ -85,7 +102,7 @@
     "\n",
     "#Execute solver\n",
     "sol = ls.solve()\n",
-    "print sol"
+    "print(sol)"
    ]
   },
   {
@@ -104,31 +121,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2018-06-18T18:49:32.089785Z",
-     "start_time": "2018-06-18T18:49:32.083575Z"
+     "end_time": "2020-06-13T00:06:10.891288Z",
+     "start_time": "2020-06-13T00:06:10.548Z"
     },
     "run_control": {
      "frozen": false,
      "read_only": false
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'y': array([ 2.,  4.]), 'x': array([ 1.,  2.])}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "data = {'3*x+4*y': np.array([11.0,22.0]), '-1*x-3*y': np.array([-7.0,-14.0])}\n",
     "ls = linsolve.LinearSolver(data)\n",
     "sol = ls.solve()\n",
-    "print sol"
+    "print(sol)"
    ]
   },
   {
@@ -147,31 +156,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2018-06-18T18:49:32.098630Z",
-     "start_time": "2018-06-18T18:49:32.091452Z"
+     "end_time": "2020-06-13T00:06:10.891963Z",
+     "start_time": "2020-06-13T00:06:10.551Z"
     },
     "run_control": {
      "frozen": false,
      "read_only": false
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'y': array([ 2., -2.]), 'x': array([  1.,  10.])}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "data = {'3*x+a*y': np.array([11.0,22.0]), 'b*x-3*y': np.array([-7.0,-14.0])}\n",
     "ls = linsolve.LinearSolver(data, a=4, b=np.array([-1,-2]))\n",
     "sol = ls.solve()\n",
-    "print sol"
+    "print(sol)"
    ]
   },
   {
@@ -188,26 +189,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2018-06-18T18:49:32.104672Z",
-     "start_time": "2018-06-18T18:49:32.100171Z"
+     "end_time": "2020-06-13T00:06:10.892560Z",
+     "start_time": "2020-06-13T00:06:10.552Z"
     },
     "run_control": {
      "frozen": false,
      "read_only": false
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "AssertionError encountered.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "try:\n",
     "    ls = linsolve.LinearSolver({'a*x':6., 'b*x':8.}) # raises an AssertionError because 'a' and 'b' are not defined.\n",
@@ -231,31 +224,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2018-06-18T18:49:32.111968Z",
-     "start_time": "2018-06-18T18:49:32.106768Z"
+     "end_time": "2020-06-13T00:06:10.893232Z",
+     "start_time": "2020-06-13T00:06:10.554Z"
     },
     "run_control": {
      "frozen": false,
      "read_only": false
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'y': (1-1j), 'x': (1+1j)}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "data = {'x': 1.0+1.0j, 'y_': 1.0+1.0j}\n",
     "ls = linsolve.LinearSolver(data)\n",
     "sol = ls.solve()\n",
-    "print sol"
+    "print(sol)"
    ]
   },
   {
@@ -274,31 +259,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2018-06-18T18:49:32.118182Z",
-     "start_time": "2018-06-18T18:49:32.113494Z"
+     "end_time": "2020-06-13T00:06:10.893948Z",
+     "start_time": "2020-06-13T00:06:10.557Z"
     },
     "run_control": {
      "frozen": false,
      "read_only": false
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'x': 1.4999999999999991}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "data = {'1*x': 2.0, 'x': 1.0}\n",
     "ls = linsolve.LinearSolver(data)\n",
     "sol = ls.solve()\n",
-    "print sol"
+    "print(sol)"
    ]
   },
   {
@@ -315,32 +292,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2018-06-18T18:49:32.125560Z",
-     "start_time": "2018-06-18T18:49:32.119626Z"
+     "end_time": "2020-06-13T00:06:10.894732Z",
+     "start_time": "2020-06-13T00:06:10.559Z"
     },
     "run_control": {
      "frozen": false,
      "read_only": false
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'x': 1.6666666666666665}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "data = {'1*x': 2.0, 'x': 1.0}\n",
     "wgts = {'1*x': 1.0, 'x': .5}\n",
     "ls = linsolve.LinearSolver(data, wgts=wgts)\n",
     "sol = ls.solve()\n",
-    "print sol"
+    "print(sol)"
    ]
   },
   {
@@ -361,28 +330,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2018-06-18T18:49:32.133142Z",
-     "start_time": "2018-06-18T18:49:32.128079Z"
+     "end_time": "2020-06-13T00:06:10.895376Z",
+     "start_time": "2020-06-13T00:06:10.561Z"
     },
     "run_control": {
      "frozen": false,
      "read_only": false
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.333333333333\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "print ls.chisq(sol)"
+    "print(ls.chisq(sol))"
    ]
   },
   {
@@ -431,31 +392,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2018-06-18T18:49:32.143172Z",
-     "start_time": "2018-06-18T18:49:32.135709Z"
+     "end_time": "2020-06-13T00:06:10.896074Z",
+     "start_time": "2020-06-13T00:06:10.562Z"
     },
     "run_control": {
      "frozen": false,
      "read_only": false
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'a': (1.9999999999999996+0j), 'c': (0.99999999999999989+0j), 'b': (1+0j)}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "data = {'a*b': 2.0, 'b*c': 1.0, 'a*c': 2.0}\n",
     "lps = linsolve.LogProductSolver(data)\n",
     "sol = lps.solve()\n",
-    "print sol"
+    "print(sol)"
    ]
   },
   {
@@ -497,26 +450,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2018-06-18T18:49:32.159183Z",
-     "start_time": "2018-06-18T18:49:32.145454Z"
+     "end_time": "2020-06-13T00:06:10.896715Z",
+     "start_time": "2020-06-13T00:06:10.567Z"
     },
     "run_control": {
      "frozen": false,
      "read_only": false
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'a': 0.99999999999999989, 'c': 3.0, 'b': 2.0}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "data = {'10*a*b + 3*b*c - 2*a*c': 32, \n",
     "        '2*a*a +3*b*b -2*c*c': -4,\n",
@@ -524,7 +469,7 @@
     "sol0 = {'a': .9, 'b': 2.1, 'c': 3.2}\n",
     "lps = linsolve.LinProductSolver(data, sol0)\n",
     "meta, sol = lps.solve_iteratively()\n",
-    "print sol"
+    "print(sol)"
    ]
   },
   {
@@ -545,28 +490,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2018-06-18T18:49:32.164027Z",
-     "start_time": "2018-06-18T18:49:32.160646Z"
+     "end_time": "2020-06-13T00:06:10.897422Z",
+     "start_time": "2020-06-13T00:06:10.568Z"
     },
     "run_control": {
      "frozen": false,
      "read_only": false
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'conv_crit': 2.9177784203741434e-13, 'chisq': 1.2552493563396059e-22, 'iter': 4}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "print meta"
+    "print(meta)"
    ]
   },
   {
@@ -586,21 +523,34 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.13"
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
   }
  },
  "nbformat": 4,

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 from setuptools import setup
 import sys
 import os.path as op


### PR DESCRIPTION
This turned out to be a bit more annoying than expected, because the classes of `ast` changed. But this works now for both python 3.7 and 3.8.