### PR TITLE
ci: add release-draft workflow

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -1,0 +1,21 @@
+name: Update Draft Release
+
+on: push
+
+jobs:
+  draft-release:
+    name: Update Draft Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Publish the release notes
+        uses: release-drafter/release-drafter@v5.21.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adds the last piece that makes releasing so much nicer: an automatic updater of the release notes so that when we want to release, the next version is already inferred from the merged PRs, and there is an automatic description based on tags of the PRs merged.