### PR TITLE
Add option to save memory when using LinProductSolver infrastructure but not its solvers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/*
 coverage.xml
 *.DS_Store
 */_version.py
+src/linsolve/_version.py

--- a/tests/test_linsolve.py
+++ b/tests/test_linsolve.py
@@ -490,6 +490,10 @@ class TestLinProductSolver:
             np.testing.assert_almost_equal(eval(k), 0.002)
         assert len(ls.ls.prms) == 3
 
+        ls = linsolve.LinProductSolver(d, sol0, w, sparse=self.sparse, build_solver=False)
+        assert not hasattr(ls, "ls")
+        assert ls.dtype == np.complex64
+
     def test_real_solve(self):
         x, y, z = 1.0, 2.0, 3.0
         keys = ["x*y", "x*z", "y*z"]


### PR DESCRIPTION
This default `False` option can help make omnical more memory efficient. 