### PR TITLE
Internally determined default value of rcond is a worse choice than the default value chosen by numpy/scipy for pinv.

### DIFF
--- a/src/linsolve/linsolve.py
+++ b/src/linsolve/linsolve.py
@@ -568,7 +568,7 @@ class LinearSolver:
         """Use np.linalg.solve to solve a system of equations.
 
         Requires a fully constrained system of equations (i.e. doesn't deal with
-        singular matrices).  Can by ~1.5x faster that lstsq for this case. 'rcond'
+        singular matrices).  Can be ~1.5x faster than lstsq for this case. 'rcond'
         is unused, but passed as an argument to match the interface of other _invert
         methods.
         """
@@ -644,8 +644,8 @@ class LinearSolver:
             a dictionary of solutions with variables as keys
         """
         assert mode in ["default", "lsqr", "pinv", "solve"]
-        if rcond is None:
-            rcond = np.finfo(self.dtype).resolution
+        #if rcond is None:
+        #    rcond = np.finfo(self.dtype).resolution
         y = self.get_weighted_data()
         if self.sparse:
             xs, ys, vals = self.get_A_sparse()

--- a/tests/test_linsolve.py
+++ b/tests/test_linsolve.py
@@ -297,6 +297,25 @@ class TestLinearSolver:
         result = ls.eval(sol, "a*b+a*x+b*y")
         np.testing.assert_almost_equal(3 * 1 + 3 * 1 + 1 * 2, list(result.values())[0])
 
+    def test_specific_system(self):
+        eqs = {
+            'Ii_R1 + Io_R1': 0.,
+            'Vi_R1 - Io_R1 * Z_R1 - Vo_R1': 0.,
+            'Ii_R2 + Io_R2': 0.,
+            'Vi_R2 - Io_R2 * Z_R2 - Vo_R2': 0.,
+            'I_s + Ii_R1': 0.,
+            'V_s - Vi_R1': 0.,
+            'Io_R1 + Ii_R2': 0.,
+            'Vo_R1 - Vi_R2': 0.,
+            'Io_R2 + I_GND': 0.,
+            'Vo_R2 - V_GND': 0.,
+        }
+        consts = {'Z_R1': 50., 'Z_R2': 50., 'V_GND': 0., 'V_s': 1.}
+        ls = linsolve.LinearSolver(eqs, **consts)
+        for mode in ('solve', 'lsqr', 'pinv', 'default'):
+            sol = ls.solve(mode=mode)
+            np.testing.assert_almost_equal(sol['Vo_R1'], 0.5, 4)
+
     def test_chisq(self):
         x = 1.0
         d = {"x": 1, "a*x": 2}


### PR DESCRIPTION
I wrote a test that exposes the problem, and fixed it by allowing rcond to carry the value None into pinv.